### PR TITLE
Automate build of .msi

### DIFF
--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -13,5 +13,6 @@ jobs:
     - uses: actions/checkout@v3
     - run: node -v
     - run: npm install
+    - run: npm run build
     - run: npm run tauri build
     - run: ls ./src-tauri/target/release/bundle/msi

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -1,0 +1,17 @@
+name: Build .msi
+
+on:
+  push:
+    branches: [ "tauri-port" ]
+  pull_request:
+    branches: [ "tauri-port" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: node -v
+    - run: npm install
+    - run: npm run tauri build
+    - run: ls ./src-tauri/target/release/bundle/msi

--- a/.github/workflows/msi.yaml
+++ b/.github/workflows/msi.yaml
@@ -2,9 +2,8 @@ name: Build .msi
 
 on:
   push:
-    branches: [ "tauri-port" ]
-  pull_request:
-    branches: [ "tauri-port" ]
+    tags:
+      - "*.*.*"
 
 jobs:
   build:
@@ -16,3 +15,8 @@ jobs:
     - run: npm run build
     - run: npm run tauri build
     - run: ls ./src-tauri/target/release/bundle/msi
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          src-tauri/target/release/bundle/msi/*


### PR DESCRIPTION
# Pull Request

Automates deployment and release of msi when pushing a tag matching *.*.* format.

## Description

I thought it would be great to automate releases of the tauri-port of yasb. It makes it easier for less-technical users to have access to this great tool.

## Testing
You can see a successful run [here](https://github.com/ingalless/yasb/actions/runs/3279473703).
