### PR TITLE
Fix typo in sample config

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -270,7 +270,7 @@ bars:
           # ^ A list of class_names the widget should ignore. Accepts: list of strings
         # process: []
           # ^ A list of process names the widget should ignore. Accepts: list of strings
-        # title:
+        # titles:
           # ^ A list of titles the widget should ignore. Accepts: list of strings
       # callbacks:
         # on_left: "toggle_label" - toggles between the clock and alternate clock labels


### PR DESCRIPTION
There's a typo in the sample config that could cause users trying to customize their own status bar instances to crash and wonder what's going on(it happened to me).

Specifically, the **active-window-widget** has a section on how to ignore certain windows, and the parameter for title's is listed as `title`([link](https://github.com/denBot/yasb/blob/2a31942223355cabe5ad34770b0eefd05b3114a1/src/config.yaml#L273)) but the actual source code is looking for `title*s*` ([link](https://github.com/denBot/yasb/blob/2a31942223355cabe5ad34770b0eefd05b3114a1/src/core/widgets/yasb/active_window.py#L64)).
