### PR TITLE
feat: add child css class for specific layout in komorebi-active-layout 

### DIFF
--- a/src/core/widgets/komorebi/active_layout.py
+++ b/src/core/widgets/komorebi/active_layout.py
@@ -144,7 +144,8 @@ class ActiveLayoutWidget(BaseWidget):
                 self._active_layout_text.setText(
                     self._label.replace("{icon}", layout_icon).replace("{layout_name}", layout_name)
                 )
-
+                self._active_layout_text.setProperty("class", f"label {layout_name}")
+                self._active_layout_text.setStyleSheet('')
                 if self._active_layout_text.isHidden():
                     self._active_layout_text.show()
         except Exception:


### PR DESCRIPTION
a small change to allow different specific layouts to have different css.



Example.

```css
.komorebi-active-layout .label.Monocle {
  color: red;
  margin-right:20px;
  font-size: 13px;
}
```