### PR TITLE
fix: Popups and prevent panic on unknown event type

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ng": "ng",
     "start": "npm run tauri:serve",
     "web:serve": "ng serve --port 4200 --live-reload",
-    "web:build": "ng build --base-href ./",
+    "web:build": "ng build --base-href /",
     "web:dev": "npm run web:build",
     "web:prod": "npm run web:build -- -c production",
     "tauri": "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ komorebi-core = { git = "https://github.com/LGUG2Z/komorebi", ref = "v0.1.15" }
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.2.4", features = ["api-all", "cli", "system-tray"] }
 ctrlc = { version = "3.2.2", features = ["termination"] }
-tokio = { version = "1.20.1", features = ["full" ] }
+tokio = { version = "1.20.1", features = ["full"] }
 
 [dev-dependencies]
 ts-rs = { version = "6.1" }
@@ -52,10 +52,10 @@ ts-rs = { version = "6.1" }
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
-default = [ "custom-protocol" ]
+default = ["custom-protocol"]
 # this feature is used used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
-custom-protocol = [ "tauri/custom-protocol" ]
+custom-protocol = ["tauri/custom-protocol"]
 
 [dependencies.windows]
 version = "0.44.0"
@@ -72,5 +72,5 @@ features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_HiDpi",
     "Win32_UI_Shell",
-    "Win32_Graphics_Gdi"
+    "Win32_Graphics_Gdi",
 ]

--- a/src-tauri/config.yaml
+++ b/src-tauri/config.yaml
@@ -5,7 +5,7 @@ bars:
     screens: []               # Optional, default: [] (all screens), takes: list of screen names to show bar on
     win_app_bar: true         # Optional, default: false, registers bar as a Windows Application Desktop Toolbar (e.g. a custom taskbar)
     always_on_top: true       # Optional, default: false, ensures bar is always at TOPMOST window level.
-    blur_effect: mica         # Optional, default: None, options: blur|acrylic|mica. Mica works on Windows 11 only. Acrylic may have poor performance.
+    blur_effect: null         # Optional, default: None, options: blur|acrylic|mica. Mica works on Windows 11 only. Acrylic may have poor performance.
     transparency: true        # Optional, default: true, enables fully transparent windows. Disable to see a white fallback window background.
     widgets:                  # Provide a list of widgets for left, middle and right bar columns
       left: [ komorebi_workspaces, active_window ]
@@ -13,7 +13,7 @@ bars:
       right: [
         # hostname_widget,
         # uptime_widget,
-        # net_usage_widget,
+        net_usage_widget,
         mem_usage_widget,
         cpu_usage_widget,
         custom_weather_widget,

--- a/src-tauri/config.yaml
+++ b/src-tauri/config.yaml
@@ -5,7 +5,7 @@ bars:
     screens: []               # Optional, default: [] (all screens), takes: list of screen names to show bar on
     win_app_bar: true         # Optional, default: false, registers bar as a Windows Application Desktop Toolbar (e.g. a custom taskbar)
     always_on_top: true       # Optional, default: false, ensures bar is always at TOPMOST window level.
-    blur_effect: null         # Optional, default: None, options: blur|acrylic|mica. Mica works on Windows 11 only. Acrylic may have poor performance.
+    blur_effect: mica         # Optional, default: None, options: blur|acrylic|mica. Mica works on Windows 11 only. Acrylic may have poor performance.
     transparency: true        # Optional, default: true, enables fully transparent windows. Disable to see a white fallback window background.
     widgets:                  # Provide a list of widgets for left, middle and right bar columns
       left: [ komorebi_workspaces, active_window ]
@@ -13,7 +13,7 @@ bars:
       right: [
         # hostname_widget,
         # uptime_widget,
-        net_usage_widget,
+        # net_usage_widget,
         mem_usage_widget,
         cpu_usage_widget,
         custom_weather_widget,

--- a/src/app/components/widgets/komorebi-workspace-widget/komorebi-workspace-widget.component.html
+++ b/src/app/components/widgets/komorebi-workspace-widget/komorebi-workspace-widget.component.html
@@ -1,14 +1,10 @@
-<div class="widget komorebi-workspaces">
+<div class="widget komorebi-workspaces" [id]="$any(props).kind">
     <div #workspaceContainer>
         <div *ngIf="komorebiState">
-            <button
-                *ngFor="let ws of workspaces"
-                class="workspace-btn"
+            <button *ngFor="let ws of workspaces" class="workspace-btn"
                 [style.display]="props.hide_empty && ws.isEmpty && !ws.isActive ? 'none' : 'inlne-block'"
-                [ngClass]="{ empty: ws.isEmpty, active: ws.isActive }"
-                [title]="ws.labelTooltip"
-                (click)="focusWorkspace(ws.index)"
-            >
+                [ngClass]="{ empty: ws.isEmpty, active: ws.isActive }" [title]="ws.labelTooltip"
+                (click)="focusWorkspace(ws.index)">
                 {{ ws.label }}
             </button>
         </div>

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -3,9 +3,18 @@
   "compilerOptions": {
     "outDir": "../out-tsc/app",
     "baseUrl": "",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "files": ["main.ts", "polyfills.ts"],
-  "include": ["**/*.d.ts"],
-  "exclude": ["**/*.spec.ts"]
+  "files": [
+    "main.ts",
+    "polyfills.ts"
+  ],
+  "include": [
+    "**/*.d.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
## Description
* Popups have been fixed in release mode
    * They were broken in release because of the `base-href` setting being relative and not absolute
* Remove panic on an unknown event type and log instead
    * Previously if there was a panic it would stop the komorebi polling thread and completely stop responding to events.

## Testing
Clicked on the clock to open the calendar to make sure it works and I'm now able to switch workspaces and see when komorebi is offline (previously it never received these events because of dead polling thread)