### PR TITLE
fix: Formatting for traffic widget in example config

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -459,8 +459,8 @@ widgets:
           on_right: "exec cmd.exe /c start ms-settings:network"
 
   traffic:
-  type: "yasb.traffic.TrafficWidget"
-  options:
+    type: "yasb.traffic.TrafficWidget"
+    options:
       label: "\ueb01 \ueab4 {download_speed} | \ueab7 {upload_speed}"
       label_alt: "\ueb01 \ueab4 {upload_speed} | \ueab7 {download_speed}"
       update_interval: 1000 # Update interval should be a multiple of 1000


### PR DESCRIPTION
# Pull Request #113 <!-- Provide reverence to GitHub Issue -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was some faulty spacing in the file, which caused the build to complain about it.